### PR TITLE
Remove unused Guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require": {
         "php": ">=7.0.0",
         "league/flysystem": "~1.0",
-        "guzzlehttp/guzzle": "~6.0",
         "platformcommunity/bunnycdn-storage": "~0.2",
         "ext-json": "*"
     },


### PR DESCRIPTION
This package does not use guzzle at all, but relies on `platformcommunity/bunnycdn-storage` instead.

Closes #5 