### PR TITLE
fix deleteDir

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -148,7 +148,7 @@ class BunnyCDNAdapter extends AbstractAdapter
     {
         try {
             return (bool)$this->bunnyCDNStorage->deleteObject(
-                $this->fullPath($dirname)
+                $this->fullPath($dirname) . "/"
             );
         // @codeCoverageIgnoreStart
         } catch (BunnyCDNStorageException $e) {


### PR DESCRIPTION
delete directory requires a trailing slash, otherwise bunny looks for a file