### PR TITLE
Fix issue where `fopen` complains when opening downloaded image file

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -191,7 +191,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
     public function readStream($path)
     {
         /** @var resource $readStream */
-        $readStream = fopen('data://text/plain,' . $this->read($path),'r');
+        $readStream = fopen('data:text/plain;base64,' . base64_encode($this->read($path)),'r');
 
         rewind($readStream);
 


### PR DESCRIPTION
This may not be an issue, but was causing me problems. This change does seem to fix it for me, but don't know if there was a specific reason for it being how it was