### PR TITLE
Fixes for MimeType Detection and getObject

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "league/flysystem": "^3.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.4"
+        "guzzlehttp/guzzle": "^7.4",
+        "league/mime-type-detection": "^1.11"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,4 +24,5 @@
         <log type="coverage-html" target="./report" lowUpperBound="50" highLowerBound="80" />
         <log type="coverage-clover" target="./clover.xml"/>
     </logging>
+    
 </phpunit>

--- a/tests/FlysystemTestSuite.php
+++ b/tests/FlysystemTestSuite.php
@@ -24,6 +24,19 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
 {
     const STORAGE_ZONE = 'testing_storage_zone';
 
+    /**
+     * Used for testing protected methods
+     *
+     * https://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit
+     */
+    public static function callMethod($obj, $name, array $args)
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($obj, $args);
+    }
+
     public static function createFilesystemAdapter(): FilesystemAdapter
     {
         $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
@@ -112,7 +125,8 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
                 new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
             );
 
-            $this->assertSame('this/is/a/long/sub/directory/source.txt', $adapter->fileSize('this/is/a/long/sub/directory/source.txt')->path());
+            $object = self::callMethod($adapter, 'getObject', ['this/is/a/long/sub/directory/source.txt']);
+            $this->assertSame('this/is/a/long/sub/directory/source.txt', $object->path());
         });
     }
 


### PR DESCRIPTION
This is for #23 and #24.

BunnyCDN doesn't return a mime-type to so the code in this implements a fill-in courtesy of a FlySystem add-on. The other issue it addresses is getObject doesn't currently pass the directory, which makes it only read objects 1 directory deep.

I should note I couldn't quite get the readStream working to read the written file to the InMemoryFilesystemAdapter to have a passing test for the fallback.