### PR TITLE
Readding content-type to the normalized object

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -150,7 +150,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
                 $bunny_file_array['Length'],
                 Visibility::PUBLIC,
                 self::parse_bunny_timestamp($bunny_file_array['LastChanged']),
-                $bunny_file_array['ContentType'],
+                $bunny_file_array['ContentType'] ?: $this->detectMimeType($bunny_file_array['Path'] . $bunny_file_array['ObjectName']),
                 $this->extractExtraMetadata($bunny_file_array)
             )
         };

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -192,11 +192,11 @@ class BunnyCDNAdapter implements FilesystemAdapter
         try {
             $detector = new FinfoMimeTypeDetector();
             $mimeType = $detector->detectMimeTypeFromPath($path);
-    
+
             if (! $mimeType) {
                 return $detector->detectMimeTypeFromBuffer(stream_get_contents($this->readStream($path), 80));
             }
-    
+
             return $mimeType;
         } catch (\Exception $e) {
             return '';

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -189,14 +189,18 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function detectMimeType(string $path): string
     {
-        $detector = new FinfoMimeTypeDetector();
-        $mimeType = $detector->detectMimeTypeFromPath($path);
-
-        if (! $mimeType) {
-            return $detector->detectMimeTypeFromBuffer(stream_get_contents($this->readStream($path), 80));
+        try {
+            $detector = new FinfoMimeTypeDetector();
+            $mimeType = $detector->detectMimeTypeFromPath($path);
+    
+            if (! $mimeType) {
+                return $detector->detectMimeTypeFromBuffer(stream_get_contents($this->readStream($path), 80));
+            }
+    
+            return $mimeType;
+        } catch (\Exception $e) {
+            return '';
         }
-
-        return $mimeType;
     }
 
     /**

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -150,7 +150,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
                 $bunny_file_array['Length'],
                 Visibility::PUBLIC,
                 self::parse_bunny_timestamp($bunny_file_array['LastChanged']),
-                $bunny_file_array['ContentType'] ?: $this->detectMimeType($bunny_file_array['Path'] . $bunny_file_array['ObjectName']),
+                $bunny_file_array['ContentType'] ?: $this->detectMimeType($bunny_file_array['Path'].$bunny_file_array['ObjectName']),
                 $this->extractExtraMetadata($bunny_file_array)
             )
         };


### PR DESCRIPTION
It looks like the content-type change to normalizeObject got removed in one of the commits. I've made it so it uses whatever is returned from Bunny first (which right now isn't anything, but when they support it will use that value) and then falls back to the detectMimeType method if needed.

Failing test is fetching_unknown_mime_type_of_a_file of FilesystemAdapterTestCase in flysystem-adapter-test-utilities

**Edit**
I fixed the issue by returning blank on error in detectMimeType. I'm not sure that's ideal, but that appears to be what the Flysystem test is looking for with the return.