### PR TITLE
fix: #35 several broken prefix paths

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -65,8 +65,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function copy($source, $destination, Config $config): void
     {
-        $this->prependPrefix($source);
-        $this->prependPrefix($destination);
+        $source = $this->prependPrefix($source);
+        $destination = $this->prependPrefix($destination);
 
         try {
             $this->write($destination, $this->read($source), new Config());
@@ -84,7 +84,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function write($path, $contents, Config $config): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $this->client->upload($path, $contents);
@@ -101,7 +101,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function read($path): string
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             return $this->client->download($path);
@@ -119,7 +119,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function listContents(string $path = '', bool $deep = false): iterable
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $entries = $this->client->list($path);
@@ -147,7 +147,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     protected function normalizeObject(array $bunny_file_array): StorageAttributes
     {
-        $bunny_file_array['Path'] = str_replace($this->prefixPath, '', $bunny_file_array['Path']);
+        $bunny_file_array['Path'] = str_replace($this->prependPrefix(''), '', $bunny_file_array['Path']);
 
         return match ($bunny_file_array['IsDirectory']) {
             true => new DirectoryAttributes(
@@ -206,7 +206,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function detectMimeType(string $path): string
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $detector = new FinfoMimeTypeDetector();
@@ -230,7 +230,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function writeStream($path, $contents, Config $config): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         $this->write($path, stream_get_contents($contents), $config);
     }
@@ -243,7 +243,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function readStream($path)
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             return $this->client->stream($path);
@@ -260,7 +260,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function deleteDirectory(string $path): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $this->client->delete(
@@ -279,7 +279,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function createDirectory(string $path, Config $config): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $this->client->make_directory($path);
@@ -300,7 +300,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function setVisibility(string $path, string $visibility): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         throw UnableToSetVisibility::atLocation($path, 'BunnyCDN does not support visibility');
     }
@@ -310,6 +310,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function visibility(string $path): FileAttributes
     {
+        $path = $this->prependPrefix($path);
+
         try {
             return new FileAttributes($this->getObject($path)->path(), null, $this->pullzone_url ? 'public' : 'private');
         } catch (UnableToReadFile|TypeError $e) {
@@ -325,6 +327,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function mimeType(string $path): FileAttributes
     {
+        $path = $this->prependPrefix($path);
+
         try {
             $object = $this->getObject($path);
 
@@ -366,7 +370,9 @@ class BunnyCDNAdapter implements FilesystemAdapter
         $directory = pathinfo($path, PATHINFO_DIRNAME);
         $list = (new DirectoryListing($this->listContents($directory)))
             ->filter(function (StorageAttributes $item) use ($path) {
-                return $item->path() === $path;
+                $itemPath = $this->prependPrefix(Util::normalizePath($item->path()));
+
+                return $itemPath === $path;
             })->toArray();
 
         if (count($list) === 1) {
@@ -388,6 +394,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function lastModified(string $path): FileAttributes
     {
+        $path = $this->prependPrefix($path);
+
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -403,6 +411,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileSize(string $path): FileAttributes
     {
+        $path = $this->prependPrefix($path);
+
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -418,8 +428,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function move(string $source, string $destination, Config $config): void
     {
-        $this->prependPrefix($source);
-        $this->prependPrefix($destination);
+        $source = $this->prependPrefix($source);
+        $destination = $this->prependPrefix($destination);
 
         try {
             $this->write($destination, $this->read($source), new Config());
@@ -435,7 +445,7 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function delete($path): void
     {
-        $this->prependPrefix($path);
+        $path = $this->prependPrefix($path);
 
         try {
             $this->client->delete($path);
@@ -462,12 +472,16 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileExists(string $path): bool
     {
+        $path = $this->prependPrefix($path);
+
         $list = new DirectoryListing($this->listContents(
             Util::splitPathIntoDirectoryAndFile($path)['dir']
         ));
 
         $count = $list->filter(function (StorageAttributes $item) use ($path) {
-            return Util::normalizePath($item->path()) === Util::normalizePath($path);
+            $itemPath = $this->prependPrefix(Util::normalizePath($item->path()));
+
+            return $itemPath === Util::normalizePath($path);
         })->toArray();
 
         return (bool) count($count);
@@ -495,20 +509,20 @@ class BunnyCDNAdapter implements FilesystemAdapter
         return (date_create_from_format('Y-m-d\TH:i:s.u', $timestamp) ?: date_create_from_format('Y-m-d\TH:i:s', $timestamp))->getTimestamp();
     }
 
-    private function prependPrefix(string &$path): void
+    private function prependPrefix(string $path): string
     {
         if ($this->prefixPath === '') {
-            return;
+            return $path;
         }
 
         if ($path === $this->prefixPath) {
-            return;
+            return $path;
         }
 
         if (\str_starts_with($path, $this->prefixPath.'/')) {
-            return;
+            return $path;
         }
 
-        $path = $this->prefixPath.'/'.$path;
+        return $this->prefixPath.'/'.$path;
     }
 }

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -147,6 +147,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     protected function normalizeObject(array $bunny_file_array): StorageAttributes
     {
+        $bunny_file_array['Path'] = str_replace($this->prefixPath, '', $bunny_file_array['Path']);
+
         return match ($bunny_file_array['IsDirectory']) {
             true => new DirectoryAttributes(
                 Util::normalizePath(
@@ -241,6 +243,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function readStream($path)
     {
+        $this->prependPrefix($path);
+
         try {
             return $this->client->stream($path);
             // @codeCoverageIgnoreStart
@@ -306,8 +310,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function visibility(string $path): FileAttributes
     {
-        $this->prependPrefix($path);
-
         try {
             return new FileAttributes($this->getObject($path)->path(), null, $this->pullzone_url ? 'public' : 'private');
         } catch (UnableToReadFile|TypeError $e) {
@@ -323,8 +325,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function mimeType(string $path): FileAttributes
     {
-        $this->prependPrefix($path);
-
         try {
             $object = $this->getObject($path);
 
@@ -363,8 +363,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     protected function getObject(string $path = ''): StorageAttributes
     {
-        $this->prependPrefix($path);
-
         $directory = pathinfo($path, PATHINFO_DIRNAME);
         $list = (new DirectoryListing($this->listContents($directory)))
             ->filter(function (StorageAttributes $item) use ($path) {
@@ -390,8 +388,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function lastModified(string $path): FileAttributes
     {
-        $this->prependPrefix($path);
-
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -407,8 +403,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileSize(string $path): FileAttributes
     {
-        $this->prependPrefix($path);
-
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -468,8 +462,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileExists(string $path): bool
     {
-        $this->prependPrefix($path);
-
         $list = new DirectoryListing($this->listContents(
             Util::splitPathIntoDirectoryAndFile($path)['dir']
         ));


### PR DESCRIPTION
This fixes two things:
- Missing path prefix for `readStream`
- `listContents` has to return items with a path **relative** to the new prefix base path. Otherwise, it would be n subdirectories from the base path. Please have a look at the S3 implementation, they are also stripping the prefix from the path object (https://github.com/thephpleague/flysystem-aws-s3-v3/blob/3.x/AwsS3V3Adapter.php#L414). This is now done in `normalizeObject`. In addition, several other methods had to be changed to not prefix the path because they are comparing against the path.

@tinect please also have a look on this. 