### PR TITLE
feat: remove own implementation for prefixing path, add support for PublicUrlGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "league/flysystem": "^3.6",
+        "league/flysystem": "^3.7",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.4",
         "league/mime-type-detection": "^1.11"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "league/flysystem": "^3.0",
+        "league/flysystem": "^3.6",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.4",
         "league/mime-type-detection": "^1.11"
@@ -19,6 +19,7 @@
         "mockery/mockery": "^1.3",
         "league/flysystem-adapter-test-utilities": "^3",
         "league/flysystem-memory": "^3.0",
+        "league/flysystem-path-prefixing": "^3.3",
         "fzaninotto/faker": "^1.5",
         "laravel/pint": "^0.2.3"
     },

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -3,6 +3,8 @@
 namespace PlatformCommunity\Flysystem\BunnyCDN;
 
 use Exception;
+use League\Flysystem\CalculateChecksumFromStream;
+use League\Flysystem\ChecksumProvider;
 use League\Flysystem\Config;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\DirectoryListing;
@@ -27,8 +29,10 @@ use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use RuntimeException;
 use TypeError;
 
-class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator
+class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider
 {
+    use CalculateChecksumFromStream;
+
     /**
      * Pull Zone URL
      *
@@ -485,5 +489,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator
         }
 
         return $subject;
+    }
+
+    public function checksum(string $path, Config $config): string
+    {
+        return $this->calculateChecksumFromStream($path, $config);
     }
 }

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -21,12 +21,13 @@ use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
+use League\Flysystem\UrlGeneration\PublicUrlGenerator;
 use League\Flysystem\Visibility;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use RuntimeException;
 use TypeError;
 
-class BunnyCDNAdapter implements FilesystemAdapter
+class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator
 {
     /**
      * Pull Zone URL
@@ -41,20 +42,17 @@ class BunnyCDNAdapter implements FilesystemAdapter
     private BunnyCDNClient $client;
 
     /**
-     * @var string
+     * @param BunnyCDNClient $client
+     * @param string $pullzone_url
      */
-    private string $prefixPath;
-
-    /**
-     * @param  BunnyCDNClient  $client
-     * @param  string  $pullzone_url
-     * @param  string  $prefixPath
-     */
-    public function __construct(BunnyCDNClient $client, string $pullzone_url = '', string $prefixPath = '')
+    public function __construct(BunnyCDNClient $client, string $pullzone_url = '')
     {
         $this->client = $client;
         $this->pullzone_url = $pullzone_url;
-        $this->prefixPath = rtrim($prefixPath, '/');
+
+        if (\func_num_args() > 2 && (string) \func_get_arg(2) !== '') {
+            throw new \RuntimeException('PrefixPath is no longer supported directly. Use PathPrefixedAdapter instead: https://flysystem.thephpleague.com/docs/adapter/path-prefixing/');
+        }
     }
 
     /**
@@ -65,9 +63,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function copy($source, $destination, Config $config): void
     {
-        $source = $this->prependPrefix($source);
-        $destination = $this->prependPrefix($destination);
-
         try {
             $this->write($destination, $this->read($source), new Config());
             // @codeCoverageIgnoreStart
@@ -84,8 +79,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function write($path, $contents, Config $config): void
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $this->client->upload($path, $contents);
             // @codeCoverageIgnoreStart
@@ -101,8 +94,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function read($path): string
     {
-        $path = $this->prependPrefix($path);
-
         try {
             return $this->client->download($path);
             // @codeCoverageIgnoreStart
@@ -117,10 +108,8 @@ class BunnyCDNAdapter implements FilesystemAdapter
      * @param  bool  $deep
      * @return iterable
      */
-    public function listContents(string $path = '', bool $deep = false): iterable
+    public function listContents(string $path, bool $deep): iterable
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $entries = $this->client->list($path);
             // @codeCoverageIgnoreStart
@@ -147,8 +136,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     protected function normalizeObject(array $bunny_file_array): StorageAttributes
     {
-        $bunny_file_array['Path'] = $this->replaceFirst($this->prependPrefix(''), '', $bunny_file_array['Path']);
-
         return match ($bunny_file_array['IsDirectory']) {
             true => new DirectoryAttributes(
                 Util::normalizePath(
@@ -206,8 +193,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function detectMimeType(string $path): string
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $detector = new FinfoMimeTypeDetector();
             $mimeType = $detector->detectMimeTypeFromPath($path);
@@ -230,8 +215,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function writeStream($path, $contents, Config $config): void
     {
-        $path = $this->prependPrefix($path);
-
         $this->write($path, stream_get_contents($contents), $config);
     }
 
@@ -243,8 +226,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function readStream($path)
     {
-        $path = $this->prependPrefix($path);
-
         try {
             return $this->client->stream($path);
             // @codeCoverageIgnoreStart
@@ -260,8 +241,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function deleteDirectory(string $path): void
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $this->client->delete(
                 rtrim($path, '/').'/'
@@ -279,8 +258,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function createDirectory(string $path, Config $config): void
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $this->client->make_directory($path);
             // @codeCoverageIgnoreStart
@@ -300,8 +277,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function setVisibility(string $path, string $visibility): void
     {
-        $path = $this->prependPrefix($path);
-
         throw UnableToSetVisibility::atLocation($path, 'BunnyCDN does not support visibility');
     }
 
@@ -310,8 +285,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function visibility(string $path): FileAttributes
     {
-        $path = $this->prependPrefix($path);
-
         try {
             return new FileAttributes($this->getObject($path)->path(), null, $this->pullzone_url ? 'public' : 'private');
         } catch (UnableToReadFile|TypeError $e) {
@@ -327,8 +300,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function mimeType(string $path): FileAttributes
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $object = $this->getObject($path);
 
@@ -368,11 +339,9 @@ class BunnyCDNAdapter implements FilesystemAdapter
     protected function getObject(string $path = ''): StorageAttributes
     {
         $directory = pathinfo($path, PATHINFO_DIRNAME);
-        $list = (new DirectoryListing($this->listContents($directory)))
+        $list = (new DirectoryListing($this->listContents($directory, false)))
             ->filter(function (StorageAttributes $item) use ($path) {
-                $itemPath = $this->prependPrefix(Util::normalizePath($item->path()));
-
-                return $itemPath === $path;
+                return Util::normalizePath($item->path()) === $path;
             })->toArray();
 
         if (count($list) === 1) {
@@ -394,8 +363,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function lastModified(string $path): FileAttributes
     {
-        $path = $this->prependPrefix($path);
-
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -411,8 +378,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileSize(string $path): FileAttributes
     {
-        $path = $this->prependPrefix($path);
-
         try {
             return $this->getObject($path);
         } catch (UnableToReadFile $e) {
@@ -428,9 +393,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function move(string $source, string $destination, Config $config): void
     {
-        $source = $this->prependPrefix($source);
-        $destination = $this->prependPrefix($destination);
-
         try {
             $this->write($destination, $this->read($source), new Config());
             $this->delete($source);
@@ -445,8 +407,6 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function delete($path): void
     {
-        $path = $this->prependPrefix($path);
-
         try {
             $this->client->delete($path);
             // @codeCoverageIgnoreStart
@@ -472,23 +432,20 @@ class BunnyCDNAdapter implements FilesystemAdapter
      */
     public function fileExists(string $path): bool
     {
-        $path = $this->prependPrefix($path);
-
         $list = new DirectoryListing($this->listContents(
-            Util::splitPathIntoDirectoryAndFile($path)['dir']
+            Util::splitPathIntoDirectoryAndFile($path)['dir'],
+            false
         ));
 
         $count = $list->filter(function (StorageAttributes $item) use ($path) {
-            $itemPath = $this->prependPrefix(Util::normalizePath($item->path()));
-
-            return $itemPath === Util::normalizePath($path);
+            return Util::normalizePath($item->path()) === Util::normalizePath($path);
         })->toArray();
 
         return (bool) count($count);
     }
 
     /**
-     * getURL method for Laravel users who want to use BunnyCDN's PullZone to retrieve a public URL
+     * @deprecated use publicUrl instead
      *
      * @param  string  $path
      * @return string
@@ -496,6 +453,16 @@ class BunnyCDNAdapter implements FilesystemAdapter
      * @noinspection PhpUnused
      */
     public function getUrl(string $path): string
+    {
+        return $this->publicUrl($path, new Config());
+    }
+
+    /**
+     * @param string $path
+     * @param Config $config
+     * @return string
+     */
+    public function publicUrl(string $path, Config $config): string
     {
         if ($this->pullzone_url === '') {
             throw new RuntimeException('In order to get a visible URL for a BunnyCDN object, you must pass the "pullzone_url" parameter to the BunnyCDNAdapter.');
@@ -509,29 +476,12 @@ class BunnyCDNAdapter implements FilesystemAdapter
         return (date_create_from_format('Y-m-d\TH:i:s.u', $timestamp) ?: date_create_from_format('Y-m-d\TH:i:s', $timestamp))->getTimestamp();
     }
 
-    private function prependPrefix(string $path): string
-    {
-        if ($this->prefixPath === '') {
-            return $path;
-        }
-
-        if ($path === $this->prefixPath) {
-            return $path;
-        }
-
-        if (\str_starts_with($path, $this->prefixPath.'/')) {
-            return $path;
-        }
-
-        return $this->prefixPath.'/'.$path;
-    }
-
-    private function replaceFirst($search, $replace, $subject)
+    private function replaceFirst(string $search, string $replace, string $subject): string
     {
         $position = strpos($subject, $search);
 
         if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
+            return (string) substr_replace($subject, $replace, $position, strlen($search));
         }
 
         return $subject;

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -42,8 +42,8 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator
     private BunnyCDNClient $client;
 
     /**
-     * @param BunnyCDNClient $client
-     * @param string $pullzone_url
+     * @param  BunnyCDNClient  $client
+     * @param  string  $pullzone_url
      */
     public function __construct(BunnyCDNClient $client, string $pullzone_url = '')
     {
@@ -458,8 +458,8 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator
     }
 
     /**
-     * @param string $path
-     * @param Config $config
+     * @param  string  $path
+     * @param  Config  $config
      * @return string
      */
     public function publicUrl(string $path, Config $config): string

--- a/tests/FlysystemTestSuite.php
+++ b/tests/FlysystemTestSuite.php
@@ -73,7 +73,7 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
         }
 
         if (isset($_SERVER['STORAGEZONE'], $_SERVER['APIKEY'])) {
-            static::$bunnyCDNClient = new BunnyCDNClient($_SERVER['STORAGEZONE'], $_SERVER['APIKEY'], \PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion\BunnyCDNRegion::NEW_YORK);
+            static::$bunnyCDNClient = new BunnyCDNClient($_SERVER['STORAGEZONE'], $_SERVER['APIKEY']);
 
             return static::$bunnyCDNClient;
         }

--- a/tests/FlysystemTestSuite.php
+++ b/tests/FlysystemTestSuite.php
@@ -125,6 +125,13 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
         return new BunnyCDNAdapter(static::bunnyCDNClient(), 'https://example.org.local/assets/');
     }
 
+    public function test_construct_throws_error(): void
+    {
+        self::expectException(\RuntimeException::class);
+        self::expectExceptionMessage('PrefixPath is no longer supported directly. Use PathPrefixedAdapter instead: https://flysystem.thephpleague.com/docs/adapter/path-prefixing/');
+        new BunnyCDNAdapter(static::bunnyCDNClient(), 'https://example.org.local/assets/', 'thisisauselessarg');
+    }
+
     /**
      * @test
      */
@@ -312,6 +319,14 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
         $url = $this->adapter()->publicUrl('/path.txt', new Config());
 
         self::assertEquals('https://example.org.local/assets/path.txt', $url);
+    }
+
+    public function test_without_pullzone_url_error_thrown_accessing_url(): void
+    {
+        self::expectException(\RuntimeException::class);
+        self::expectExceptionMessage('In order to get a visible URL for a BunnyCDN object, you must pass the "pullzone_url" parameter to the BunnyCDNAdapter.');
+        $myAdapter = new BunnyCDNAdapter(static::bunnyCDNClient());
+        $myAdapter->publicUrl('/path.txt', new Config());
     }
 
     /**
@@ -567,5 +582,11 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
         $response = $adapter->read('/test.json');
 
         $this->assertIsString($response);
+    }
+
+    public function test_replace_first()
+    {
+        self::assertSame('SX', $this->callMethod($this->adapter(), 'replaceFirst', ['X', 'S', 'XX']));
+        self::assertSame('ORIGINAL', $this->callMethod($this->adapter(), 'replaceFirst', ['X', 'S', 'ORIGINAL']));
     }
 }

--- a/tests/FlysystemTestSuite.php
+++ b/tests/FlysystemTestSuite.php
@@ -396,7 +396,7 @@ class FlysystemTestSuite extends FilesystemAdapterTestCase
      */
     public function overwriting_a_file(): void
     {
-        $this->runScenario(function() {
+        $this->runScenario(function () {
             $this->givenWeHaveAnExistingFile('path.txt', 'contents', ['visibility' => Visibility::PUBLIC]);
             $adapter = $this->adapter();
 


### PR DESCRIPTION
Sorry, I was too productive :-(

I've added `PublicUrlGenerator` introduced with flysystem 3.6. Therefore, I raised the min version. Should fit, doesn't it?

The arguments from `listContents` should not be optional regarding the Interface. I saw it by testing the PathPrefixedAdapter.

While removing the own implemented PathPrefixing I kept the tests for the moment, to show that they are working :-)
As shown in issue, the test for `path` seems wrong because I cannot reproduce the expected result anywhere.  Therefore, I deleted this part.

Additionally, I added support for https://flysystem.thephpleague.com/docs/usage/checksums/

Closes #47