### PR TITLE
doc: rename L.A. CDN Region

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ BunnyCDNRegion::UNITED_KINGDOM = 'uk';
 
 # USA
 BunnyCDNRegion::NEW_YORK = 'ny';
-BunnyCDNRegion::LOS_ANGELAS = 'la';
+BunnyCDNRegion::LOS_ANGELES = 'la';
 
 # SEA
 BunnyCDNRegion::SINGAPORE = 'sg';

--- a/src/BunnyCDNRegion.php
+++ b/src/BunnyCDNRegion.php
@@ -10,7 +10,7 @@ class BunnyCDNRegion
 
     public const NEW_YORK = 'ny';
 
-    public const LOS_ANGELAS = 'la';
+    public const LOS_ANGELES = 'la';
 
     public const SINGAPORE = 'sg';
 


### PR DESCRIPTION
Hey, folks!

How's going on?

A little fix about CDN Los Angeles region constant.

Maybe I'm wrong or it was done as excepted CDN region name.

Thanks for your Flysystem support!