### PR TITLE
Ensure base url is correct when the API returns uppercase region

### DIFF
--- a/src/BunnyCDNClient.php
+++ b/src/BunnyCDNClient.php
@@ -29,7 +29,7 @@ class BunnyCDNClient
 
     private static function get_base_url($region): string
     {
-        return match ($region) {
+        return match (strtolower($region)) {
             BunnyCDNRegion::NEW_YORK => 'https://ny.storage.bunnycdn.com/',
             BunnyCDNRegion::LOS_ANGELAS => 'https://la.storage.bunnycdn.com/',
             BunnyCDNRegion::SINGAPORE => 'https://sg.storage.bunnycdn.com/',


### PR DESCRIPTION
In my case, I receive SYD for the region name. The system is looking for syd. So by forcing the match to lowercase, it gets the region correctly