### PR TITLE
fix: ignore NotFoundExceoption when deleting directory

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -27,6 +27,7 @@ use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\UrlGeneration\PublicUrlGenerator;
 use League\Flysystem\Visibility;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
 use RuntimeException;
 use TypeError;
 
@@ -252,6 +253,8 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
                 rtrim($path, '/').'/'
             );
             // @codeCoverageIgnoreStart
+        } catch (NotFoundException) {
+            // nth
         } catch (Exceptions\BunnyCDNException $e) {
             throw UnableToDeleteDirectory::atLocation($path, $e->getMessage());
         }
@@ -462,10 +465,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         try {
             $this->client->delete($path);
             // @codeCoverageIgnoreStart
+        } catch (NotFoundException) {
+            // nth
         } catch (Exceptions\BunnyCDNException $e) {
-            if (! str_contains($e->getMessage(), '404')) { // Urgh
-                throw UnableToDeleteFile::atLocation($path, $e->getMessage());
-            }
+            throw UnableToDeleteFile::atLocation($path, $e->getMessage());
         }
         // @codeCoverageIgnoreEnd
     }

--- a/src/BunnyCDNClient.php
+++ b/src/BunnyCDNClient.php
@@ -5,7 +5,6 @@ namespace PlatformCommunity\Flysystem\BunnyCDN;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\GuzzleException;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\BunnyCDNException;
-use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\DirectoryNotEmptyException;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
 
 class BunnyCDNClient
@@ -204,7 +203,7 @@ class BunnyCDNClient
      * @return mixed
      *
      * @throws NotFoundException
-     * @throws DirectoryNotEmptyException|BunnyCDNException
+     * @throws BunnyCDNException
      */
     public function delete(string $path): mixed
     {
@@ -214,7 +213,6 @@ class BunnyCDNClient
         } catch (GuzzleException $e) {
             throw match ($e->getCode()) {
                 404 => new NotFoundException($e->getMessage()),
-                400 => new DirectoryNotEmptyException($e->getMessage()),
                 default => new BunnyCDNException($e->getMessage())
             };
         }

--- a/src/Exceptions/DirectoryNotEmptyException.php
+++ b/src/Exceptions/DirectoryNotEmptyException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PlatformCommunity\Flysystem\BunnyCDN\Exceptions;
-
-class DirectoryNotEmptyException extends BunnyCDNException
-{
-}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\BunnyCDNException;
-use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\DirectoryNotEmptyException;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
 
 if (\is_file(__DIR__.'/ClientDI.php')) {
@@ -167,7 +166,6 @@ class ClientTest extends TestCase
      * @return void
      *
      * @throws BunnyCDNException
-     * @throws DirectoryNotEmptyException
      * @throws NotFoundException
      */
     public function test_delete_file()
@@ -187,7 +185,6 @@ class ClientTest extends TestCase
      * @return void
      *
      * @throws BunnyCDNException
-     * @throws DirectoryNotEmptyException
      * @throws NotFoundException
      */
     public function test_delete_file_not_found()

--- a/tests/MockClient.php
+++ b/tests/MockClient.php
@@ -10,7 +10,6 @@ use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use League\Flysystem\StorageAttributes;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\BunnyCDNException;
-use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\DirectoryNotEmptyException;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
 use PlatformCommunity\Flysystem\BunnyCDN\Util;
 
@@ -109,7 +108,6 @@ class MockClient extends BunnyCDNClient
      *
      * @throws FilesystemException
      * @throws BunnyCDNException
-     * @throws DirectoryNotEmptyException
      * @throws NotFoundException
      */
     public function delete(string $path): array


### PR DESCRIPTION
- removing not existing directory should not throw any exception
  - it is not caught by any test (not here, nor at flysystem)
  - handling directory is not strict
- DirectoryNotEmptyException is not needed while it is never thrown, is it?