### PR TITLE
Ability to add query params to a temporary URL

### DIFF
--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -586,6 +586,12 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
         // extract our query params
         parse_str($parts['query'] ?? '', $params);
+
+        // check if we are passing additional query parameters
+        if (($queryParams = $config->get('withQueryParams')) && is_array($queryParams)) {
+            $params = array_merge($params, $queryParams);
+        }
+
         ksort($params);
 
         // concatenate all of our data

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -582,14 +582,14 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
         // extract elements from our path
         $parts = parse_url($path);
-        $path = $parts['path'];
+        $path = str_starts_with($parts['path'], '/') ? $path : '/'.$path;
 
         // extract our query params
         parse_str($parts['query'] ?? '', $params);
         ksort($params);
 
         // concatenate all of our data
-        return $path
+        return $this->pullzone_url.$path
             .(str_contains($path, '?') ? '&' : '?')
             .'token='.$this->buildSigningKey($path, $expiration, $params)
             .'&expires='.$expiration
@@ -598,9 +598,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
     private function buildSigningKey($path, int $expiration, array $params): string
     {
-        // prefix our path
-        $path = str_starts_with($path, '/') ? $path : '/'.$path;
-
         // process our query params
         $query = implode('&', array_map(fn ($k, $v) => $k.'='.$v, array_keys($params), $params));
 

--- a/tests/TemporaryUrlTest.php
+++ b/tests/TemporaryUrlTest.php
@@ -34,4 +34,22 @@ class TemporaryUrlTest extends TestCase
         $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
         $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
     }
+
+    public function test_it_will_accept_query_params()
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config([
+            'withQueryParams' => [
+                'testParam' => 'testValue',
+            ],
+        ]));
+
+        $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
+        $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
+        $this->assertStringContainsString('testParam=testValue', $url);
+    }
 }

--- a/tests/TemporaryUrlTest.php
+++ b/tests/TemporaryUrlTest.php
@@ -25,13 +25,13 @@ class TemporaryUrlTest extends TestCase
     public function test_it_can_generate_signing_key()
     {
         $client = new BunnyCDNClient('test', 'test');
-        $adapter = new BunnyCDNAdapter($client, 'pz-key');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk');
         $adapter->setTokenAuthKey('test-auth-key');
 
         $expiresAt = new \DateTimeImmutable('+1 hour');
         $url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config());
 
-        $this->assertStringContainsString('testing.txt?token=', $url);
+        $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
         $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
     }
 }


### PR DESCRIPTION
This is an addition to the temporaryUrl feature which will allow adding additional query parameters via the Config

Example usage:

```php
$url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config([
    'withQueryParams' => [
        'testParam' => 'testValue',
    ],
]));
```