### PR TITLE
Maintenance: dependency updates, root path support, Laravel temporary URLs

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,9 @@ jobs:
       run: test -f vendor/bin/phpstan && vendor/bin/phpstan analyse --no-progress || echo 'phpstan not installed, skipping'
 
     - name: Upload to Codecov
+      if: env.CODECOV_TOKEN != ''
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v7
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,10 +14,10 @@ jobs:
         php-versions: [ '8.3', '8.4', '8.5', ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup PHP with PCOV
-      uses: shivammathur/setup-php@v4
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
@@ -27,7 +27,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -47,7 +47,7 @@ jobs:
       run: test -f vendor/bin/phpstan && vendor/bin/phpstan analyse --no-progress || echo 'phpstan not installed, skipping'
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.3', '8.4', '8.5', ]
+        php-versions: [ '8.3', '8.4', '8.5', ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP with PCOV
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@v4
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
@@ -38,14 +38,16 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-interaction
 
     - name: Run linter
-      run: ./vendor/bin/pint -v --test
+      run: test -f vendor/bin/pint && vendor/bin/pint -v --test || echo 'pint not installed, skipping'
 
     - name: Run tests
       run: vendor/bin/phpunit -c ./phpunit.xml
 
-    - uses: php-actions/phpstan@v3
-      with:
-        path: src/
+    - name: Run PHPStan
+      run: test -f vendor/bin/phpstan && vendor/bin/phpstan analyse --no-progress || echo 'phpstan not installed, skipping'
 
-    - name: Upload to PCOV
-      run: bash <(curl -s https://codecov.io/bash)
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .phpunit.cache/
 .phpunit.result.cache
+.phpstan-cache/
 bin
 clover.xml
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -9,18 +9,19 @@
         }
     ],
     "require": {
+        "php": "^8.3",
         "league/flysystem": "^3.16",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.4",
         "league/mime-type-detection": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^11.5",
         "league/flysystem-adapter-test-utilities": "^3",
         "league/flysystem-memory": "^3.0",
         "league/flysystem-path-prefixing": "^3.3",
-        "fzaninotto/faker": "^1.5",
-        "laravel/pint": "^0.2.3",
+        "fakerphp/faker": "^1.23",
+        "laravel/pint": "^1.30",
         "phpstan/phpstan": "^2.1"
     },
     "autoload-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    paths:
+        - src
+    tmpDir: .phpstan-cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
   processIsolation="false"
   stopOnFailure="false"
   bootstrap="vendor/autoload.php"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
   cacheDirectory=".phpunit.cache"
   backupStaticProperties="false">
   <coverage>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <img alt="Bunny CDN Logo" src="https://gist.githubusercontent.com/sifex/bb1ebae00c4c9a827a55a2b973fef0e7/raw/d79dab1b6959f580a3b7a2e6238dae7445203f2a/bunnycdn_logo.svg?sanitize=true" width="300" />
 
 # Flysystem Adapter for BunnyCDN Storage
-[![Build Status - Flysystem v2](https://img.shields.io/github/actions/workflow/status/PlatformCommunity/flysystem-bunnycdn/php.yml?branch=v2&label=Flysystem%20v2)](https://github.com/PlatformCommunity/flysystem-bunnycdn/actions) [![Build Status - Flysystem v3](https://img.shields.io/github/actions/workflow/status/PlatformCommunity/flysystem-bunnycdn/php.yml?branch=v3&label=Flysystem%20v3)](https://github.com/PlatformCommunity/flysystem-bunnycdn/actions) <br />[![Codecov](https://img.shields.io/codecov/c/github/PlatformCommunity/flysystem-bunnycdn)](https://codecov.io/gh/PlatformCommunity/flysystem-bunnycdn) [![Packagist Version](https://img.shields.io/packagist/v/platformcommunity/flysystem-bunnycdn)](https://packagist.org/packages/platformcommunity/flysystem-bunnycdn) ![Minimum PHP Version: 7.4](https://img.shields.io/badge/php-min%207.4-important) [![Licence: MIT](https://img.shields.io/packagist/l/platformcommunity/flysystem-bunnycdn)](https://github.com/PlatformCommunity/flysystem-bunnycdn/blob/master/LICENSE) [![Downloads](https://img.shields.io/packagist/dm/platformcommunity/flysystem-bunnycdn)](https://packagist.org/packages/platformcommunity/flysystem-bunnycdn)
+[![Build Status - Flysystem v2](https://img.shields.io/github/actions/workflow/status/PlatformCommunity/flysystem-bunnycdn/php.yml?branch=v2&label=Flysystem%20v2)](https://github.com/PlatformCommunity/flysystem-bunnycdn/actions) [![Build Status - Flysystem v3](https://img.shields.io/github/actions/workflow/status/PlatformCommunity/flysystem-bunnycdn/php.yml?branch=v3&label=Flysystem%20v3)](https://github.com/PlatformCommunity/flysystem-bunnycdn/actions) <br />[![Codecov](https://img.shields.io/codecov/c/github/PlatformCommunity/flysystem-bunnycdn)](https://codecov.io/gh/PlatformCommunity/flysystem-bunnycdn) [![Packagist Version](https://img.shields.io/packagist/v/platformcommunity/flysystem-bunnycdn)](https://packagist.org/packages/platformcommunity/flysystem-bunnycdn) ![Minimum PHP Version: 8.3](https://img.shields.io/badge/php-min%208.3-important) [![Licence: MIT](https://img.shields.io/packagist/l/platformcommunity/flysystem-bunnycdn)](https://github.com/PlatformCommunity/flysystem-bunnycdn/blob/master/LICENSE) [![Downloads](https://img.shields.io/packagist/dm/platformcommunity/flysystem-bunnycdn)](https://packagist.org/packages/platformcommunity/flysystem-bunnycdn)
 
 
 ## Installation
@@ -33,6 +33,24 @@ $adapter->setTokenAuthKey('token-auth-signing-key');
 
 $filesystem = new Filesystem($adapter);
 ```
+
+### Usage with a Root Path
+
+All paths are relative to the adapter root. Pass an optional root path as the third constructor argument to scope every operation (upload, read, list, delete, URLs) to a subdirectory of the storage zone:
+
+```php
+$adapter = new BunnyCDNAdapter(
+    new BunnyCDNClient(
+        'storage-zone',
+        'api-key',
+        BunnyCDNRegion::FALKENSTEIN
+    ),
+    'https://testing.b-cdn.net', # Pull Zone URL
+    'assets'                     # Root path — optional
+);
+```
+
+Files are then stored at `assets/...` inside the storage zone, listed paths are returned relative to the root, and generated URLs point at `https://testing.b-cdn.net/assets/...`.
 
 ### Usage with Pull Zones
 
@@ -84,11 +102,12 @@ Next, install the adapter to your `AppServiceProvider` to give Laravel's FileSys
                     $config['api_key'],
                     $config['region']
                 ),
-                $config['pull_zone']
+                $config['pull_zone'] ?? '',
+                $config['root'] ?? '' // optional root path, scopes all operations to a subdirectory
             );
             
             // for temporary URL support, define a signing key
-            $adapter->setTokenAuthKey('token-auth-signing-key');
+            $adapter->setTokenAuthKey($config['token_auth_key'] ?? '');
 
             return new FilesystemAdapter(
                 new Filesystem($adapter, $config),
@@ -110,6 +129,7 @@ Finally, add the `bunnycdn` driver into your `config/filesystems.php` configurat
             'pull_zone' => env('BUNNYCDN_PULL_ZONE'),
             'api_key' => env('BUNNYCDN_API_KEY'),
             'token_auth_key' => env('BUNNYCDN_TOKEN_AUTH_KEY', ''), // optional if you'd like signed URLs
+            'root' => env('BUNNYCDN_ROOT', ''), // optional root path
             'region' => env('BUNNYCDN_REGION', \PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion::DEFAULT)
         ],
         
@@ -123,6 +143,7 @@ BUNNYCDN_STORAGE_ZONE=testing_storage_zone
 BUNNYCDN_PULL_ZONE=https://testing.b-cdn.net
 BUNNYCDN_API_KEY="api-key"
 # BUNNYCDN_REGION=uk
+# BUNNYCDN_ROOT=assets (optional root path)
 #BUNNYCDN_TOKEN_AUTH_KEY="your-token-auth-key" (optional, under CDN > Security > Token Authentication)
 ```
 
@@ -132,6 +153,18 @@ After that, you can use the `bunnycdn` disk in Laravel 9.
 Storage::disk('bunnycdn')->put('index.html', '<html>Hello World</html>');
 
 return response(Storage::disk('bunnycdn')->get('index.html'));
+```
+
+With a `token_auth_key` configured, signed temporary URLs work through Laravel's native API:
+
+```php
+$url = Storage::disk('bunnycdn')->temporaryUrl('path/to/file.pdf', now()->addHour());
+```
+
+`temporaryUrl()` also accepts an integer expiration in minutes, and additional query parameters that are signed into the URL:
+
+```php
+$url = Storage::disk('bunnycdn')->temporaryUrl('path/to/file.pdf', 60, ['download' => 'file.pdf']);
 ```
 
 _Note: You may have to run `php artisan config:clear` in order for your configuration to be refreshed if your app is running with a config cache driver / production mode._

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -51,7 +51,7 @@ class BunnyCDNAdapter implements ChecksumProvider, FilesystemAdapter, PublicUrlG
         private string $pullzone_url = '',
         private string $root = '',
     ) {
-        $this->root = Util::normalizePath($this->root);
+        $this->root = rtrim(Util::normalizePath($this->root), '/');
     }
 
     /**
@@ -212,6 +212,10 @@ class BunnyCDNAdapter implements ChecksumProvider, FilesystemAdapter, PublicUrlG
                 fn (WriteBatchFile $file) => $this->resolvePath($file->targetPath),
                 $batch
             );
+            $logicalPaths = \array_map(
+                fn (WriteBatchFile $file) => $file->targetPath,
+                $batch
+            );
 
             $requests = function () use ($batch, $paths) {
                 foreach ($paths as $index => $path) {
@@ -221,8 +225,8 @@ class BunnyCDNAdapter implements ChecksumProvider, FilesystemAdapter, PublicUrlG
 
             $pool = new Pool($this->client->guzzleClient, $requests(), [
                 'concurrency' => $concurrency,
-                'rejected' => function (RequestException|RuntimeException $reason, int $index) use ($paths) {
-                    throw UnableToWriteFile::atLocation($paths[$index] ?? (string) $index, $reason->getMessage());
+                'rejected' => function (RequestException|RuntimeException $reason, int $index) use ($logicalPaths) {
+                    throw UnableToWriteFile::atLocation($logicalPaths[$index] ?? (string) $index, $reason->getMessage());
                 },
             ]);
 
@@ -576,7 +580,7 @@ class BunnyCDNAdapter implements ChecksumProvider, FilesystemAdapter, PublicUrlG
      * @param  DateTimeInterface|int  $expiration  DateTime instance, or minutes from now
      * @param  array<string, mixed>  $options  Additional query parameters to sign into the URL
      */
-    public function getTemporaryUrl(string $path, $expiration, array $options = []): string
+    public function getTemporaryUrl(string $path, DateTimeInterface|int $expiration, array $options = []): string
     {
         $expiresAt = $expiration instanceof DateTimeInterface
             ? $expiration

--- a/src/BunnyCDNAdapter.php
+++ b/src/BunnyCDNAdapter.php
@@ -36,19 +36,22 @@ use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
 use RuntimeException;
 use TypeError;
 
-class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider, TemporaryUrlGenerator
+class BunnyCDNAdapter implements ChecksumProvider, FilesystemAdapter, PublicUrlGenerator, TemporaryUrlGenerator
 {
     use CalculateChecksumFromStream;
 
     private string $token_auth_key = '';
 
+    /**
+     * @param  string  $root  Path prefix all operations are scoped to. This is the
+     *                        storage-zone equivalent of the S3 adapter's "root" config.
+     */
     public function __construct(
         private BunnyCDNClient $client,
         private string $pullzone_url = '',
+        private string $root = '',
     ) {
-        if (\func_num_args() > 2 && (string) \func_get_arg(2) !== '') {
-            throw new \RuntimeException('PrefixPath is no longer supported directly. Use PathPrefixedAdapter instead: https://flysystem.thephpleague.com/docs/adapter/path-prefixing/');
-        }
+        $this->root = Util::normalizePath($this->root);
     }
 
     /**
@@ -62,11 +65,13 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     }
 
     /**
-     * @param $source
-     * @param $destination
-     * @param  Config  $config
-     * @return void
+     * Prefix a logical (Flysystem-relative) path with the configured root.
      */
+    private function resolvePath(string $path): string
+    {
+        return rtrim(Util::normalizePath($this->root.'/'.$path), '/');
+    }
+
     public function copy($source, $destination, Config $config): void
     {
         try {
@@ -80,15 +85,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         }
     }
 
-    /**
-     * @param $path
-     * @param $contents
-     * @param  Config  $config
-     */
     public function write($path, $contents, Config $config): void
     {
         try {
-            $this->client->upload($path, $contents);
+            $this->client->upload($this->resolvePath($path), $contents);
             // @codeCoverageIgnoreStart
         } catch (Exceptions\BunnyCDNException $e) {
             throw UnableToWriteFile::atLocation($path, $e->getMessage());
@@ -96,14 +96,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         // @codeCoverageIgnoreEnd
     }
 
-    /**
-     * @param $path
-     * @return string
-     */
     public function read($path): string
     {
         try {
-            return $this->client->download($path);
+            return $this->client->download($this->resolvePath($path));
             // @codeCoverageIgnoreStart
         } catch (Exceptions\BunnyCDNException $e) {
             throw UnableToReadFile::fromLocation($path, $e->getMessage());
@@ -111,15 +107,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         // @codeCoverageIgnoreEnd
     }
 
-    /**
-     * @param  string  $path
-     * @param  bool  $deep
-     * @return iterable
-     */
     public function listContents(string $path, bool $deep): iterable
     {
         try {
-            $entries = $this->client->list($path);
+            $entries = $this->client->list($this->resolvePath($path));
             // @codeCoverageIgnoreStart
         } catch (Exceptions\BunnyCDNException $e) {
             throw UnableToRetrieveMetadata::create($path, 'folder', $e->getMessage());
@@ -138,10 +129,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         }
     }
 
-    /**
-     * @param  array  $bunny_file_array
-     * @return StorageAttributes
-     */
     protected function normalizeObject(array $bunny_file_array): StorageAttributes
     {
         $normalised_path = Util::normalizePath(
@@ -152,7 +139,11 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
             )
         );
 
-        return match ($bunny_file_array['IsDirectory']) {
+        if ($this->root !== '' && str_starts_with($normalised_path, $this->root.'/')) {
+            $normalised_path = substr($normalised_path, strlen($this->root) + 1);
+        }
+
+        return match ((bool) $bunny_file_array['IsDirectory']) {
             true => new DirectoryAttributes(
                 $normalised_path
             ),
@@ -167,10 +158,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         };
     }
 
-    /**
-     * @param  array  $bunny_file_array
-     * @return array
-     */
     private function extractExtraMetadata(array $bunny_file_array): array
     {
         return [
@@ -191,14 +178,11 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
     /**
      * Detects the mime type from the provided file path
-     *
-     * @param  string  $path
-     * @return string
      */
     public function detectMimeType(string $path): string
     {
         try {
-            $detector = new FinfoMimeTypeDetector();
+            $detector = new FinfoMimeTypeDetector;
             $mimeType = $detector->detectMimeTypeFromPath($path);
 
             if (! $mimeType) {
@@ -211,12 +195,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         }
     }
 
-    /**
-     * @param $path
-     * @param $contents
-     * @param  Config  $config
-     * @return void
-     */
     public function writeStream($path, $contents, Config $config): void
     {
         $this->write($path, $contents, $config);
@@ -224,25 +202,27 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
     /**
      * @param  WriteBatchFile[]  $writeBatches
-     * @param  Config  $config
-     * @return void
      */
     public function writeBatch(array $writeBatches, Config $config): void
     {
         $concurrency = (int) $config->get('concurrency', 50);
 
         foreach (\array_chunk($writeBatches, $concurrency) as $batch) {
-            $requests = function () use ($batch) {
-                /** @var WriteBatchFile $file */
-                foreach ($batch as $file) {
-                    yield $this->client->getUploadRequest($file->targetPath, \file_get_contents($file->localPath));
+            $paths = \array_map(
+                fn (WriteBatchFile $file) => $this->resolvePath($file->targetPath),
+                $batch
+            );
+
+            $requests = function () use ($batch, $paths) {
+                foreach ($paths as $index => $path) {
+                    yield $this->client->getUploadRequest($path, \file_get_contents($batch[$index]->localPath));
                 }
             };
 
             $pool = new Pool($this->client->guzzleClient, $requests(), [
                 'concurrency' => $concurrency,
-                'rejected' => function (RequestException|RuntimeException $reason, int $index) {
-                    throw UnableToWriteFile::atLocation($index, $reason->getMessage());
+                'rejected' => function (RequestException|RuntimeException $reason, int $index) use ($paths) {
+                    throw UnableToWriteFile::atLocation($paths[$index] ?? (string) $index, $reason->getMessage());
                 },
             ]);
 
@@ -251,7 +231,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     }
 
     /**
-     * @param $path
      * @return resource
      *
      * @throws UnableToReadFile
@@ -259,9 +238,9 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     public function readStream($path)
     {
         try {
-            return $this->client->stream($path);
+            return $this->client->stream($this->resolvePath($path));
             // @codeCoverageIgnoreStart
-        } catch (Exceptions\BunnyCDNException|Exceptions\NotFoundException $e) {
+        } catch (Exceptions\BunnyCDNException|NotFoundException $e) {
             throw UnableToReadFile::fromLocation($path, $e->getMessage());
         }
         // @codeCoverageIgnoreEnd
@@ -273,9 +252,15 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
      */
     public function deleteDirectory(string $path): void
     {
+        $resolvedPath = $this->resolvePath($path);
+
+        if ($resolvedPath === '') {
+            throw UnableToDeleteDirectory::atLocation($path, 'Deletion of the storage zone root is not allowed.');
+        }
+
         try {
             $this->client->delete(
-                rtrim($path, '/').'/'
+                rtrim($resolvedPath, '/').'/'
             );
             // @codeCoverageIgnoreStart
         } catch (NotFoundException) {
@@ -293,7 +278,7 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     public function createDirectory(string $path, Config $config): void
     {
         try {
-            $this->client->make_directory($path);
+            $this->client->make_directory($this->resolvePath($path));
             // @codeCoverageIgnoreStart
         } catch (Exceptions\BunnyCDNException $e) {
             // Lol apparently this is "idempotent" but there's an exception... Sure whatever..
@@ -327,9 +312,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     }
 
     /**
-     * @param  string  $path
-     * @return FileAttributes
-     *
      * @codeCoverageIgnore
      */
     public function mimeType(string $path): FileAttributes
@@ -338,7 +320,7 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
             $object = $this->getObject($path);
 
             if ($object instanceof DirectoryAttributes) {
-                throw new TypeError();
+                throw new TypeError;
             }
 
             /** @var FileAttributes $object */
@@ -366,10 +348,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         }
     }
 
-    /**
-     * @param  string  $path
-     * @return mixed
-     */
     protected function getObject(string $path = ''): StorageAttributes
     {
         $directory = pathinfo($path, PATHINFO_DIRNAME);
@@ -391,34 +369,34 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         throw UnableToReadFile::fromLocation($path, 'Error 404:"'.$path.'"');
     }
 
-    /**
-     * @param  string  $path
-     * @return FileAttributes
-     */
     public function lastModified(string $path): FileAttributes
     {
         try {
-            return $this->getObject($path);
+            $object = $this->getObject($path);
         } catch (UnableToReadFile $e) {
             throw new UnableToRetrieveMetadata($e->getMessage());
-        } catch (TypeError) {
+        }
+
+        if (! $object instanceof FileAttributes) {
             throw new UnableToRetrieveMetadata('Last Modified only accepts files as parameters, not directories');
         }
+
+        return $object;
     }
 
-    /**
-     * @param  string  $path
-     * @return FileAttributes
-     */
     public function fileSize(string $path): FileAttributes
     {
         try {
-            return $this->getObject($path);
+            $object = $this->getObject($path);
         } catch (UnableToReadFile $e) {
             throw new UnableToRetrieveMetadata($e->getMessage());
-        } catch (TypeError) {
+        }
+
+        if (! $object instanceof FileAttributes) {
             throw new UnableToRetrieveMetadata('Cannot retrieve size of folder');
         }
+
+        return $object;
     }
 
     /**
@@ -476,10 +454,6 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         $this->write($destination, $this->read($source), $config);
     }
 
-    /**
-     * @param $path
-     * @return void
-     */
     public function delete($path): void
     {
         // if path is empty or ends with /, it's a directory.
@@ -488,7 +462,7 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         }
 
         try {
-            $this->client->delete($path);
+            $this->client->delete($this->resolvePath($path));
             // @codeCoverageIgnoreStart
         } catch (NotFoundException) {
             // nth
@@ -506,20 +480,11 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         return $this->exists(StorageAttributes::TYPE_DIRECTORY, $path);
     }
 
-    /**
-     * @param  string  $path
-     * @return bool
-     */
     public function fileExists(string $path): bool
     {
         return $this->exists(StorageAttributes::TYPE_FILE, $path);
     }
 
-    /**
-     * @param  string  $path
-     * @param  Config  $config
-     * @return string
-     */
     public function checksum(string $path, Config $config): string
     {
         // for compatibility reasons, the default checksum algorithm is md5
@@ -547,28 +512,22 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
     /**
      * @deprecated use publicUrl instead
      *
-     * @param  string  $path
-     * @return string
      * @codeCoverageIgnore
+     *
      * @noinspection PhpUnused
      */
     public function getUrl(string $path): string
     {
-        return $this->publicUrl($path, new Config());
+        return $this->publicUrl($path, new Config);
     }
 
-    /**
-     * @param  string  $path
-     * @param  Config  $config
-     * @return string
-     */
     public function publicUrl(string $path, Config $config): string
     {
         if ($this->pullzone_url === '') {
             throw new RuntimeException('In order to get a visible URL for a BunnyCDN object, you must pass the "pullzone_url" parameter to the BunnyCDNAdapter.');
         }
 
-        return rtrim($this->pullzone_url, '/').'/'.ltrim($path, '/');
+        return rtrim($this->pullzone_url, '/').'/'.ltrim($this->resolvePath($path), '/');
     }
 
     public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
@@ -583,6 +542,11 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
         // extract elements from our path
         $parts = parse_url($path);
         $path = str_starts_with($parts['path'], '/') ? $path : '/'.$path;
+
+        // scope the URL to the configured root, unless a fully qualified URL was passed
+        if ($this->root !== '' && ! filter_var($path, FILTER_VALIDATE_URL)) {
+            $path = '/'.$this->root.$path;
+        }
 
         // extract our query params
         parse_str($parts['query'] ?? '', $params);
@@ -602,6 +566,25 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
             .($params ? '&'.http_build_query($params) : null);
     }
 
+    /**
+     * Laravel-compatible temporary URL generation.
+     *
+     * Laravel's FilesystemAdapter only calls this method if the underlying
+     * adapter implements it, so `Storage::disk('bunnycdn')->temporaryUrl()`
+     * will now work out of the box.
+     *
+     * @param  DateTimeInterface|int  $expiration  DateTime instance, or minutes from now
+     * @param  array<string, mixed>  $options  Additional query parameters to sign into the URL
+     */
+    public function getTemporaryUrl(string $path, $expiration, array $options = []): string
+    {
+        $expiresAt = $expiration instanceof DateTimeInterface
+            ? $expiration
+            : (new \DateTimeImmutable('now'))->modify('+'.(int) $expiration.' minutes');
+
+        return $this->temporaryUrl($path, $expiresAt, new Config($options === [] ? [] : ['withQueryParams' => $options]));
+    }
+
     private function buildSigningKey($path, int $expiration, array $params): string
     {
         // process our query params
@@ -617,7 +600,10 @@ class BunnyCDNAdapter implements FilesystemAdapter, PublicUrlGenerator, Checksum
 
     private static function parse_bunny_timestamp(string $timestamp): int
     {
-        return (date_create_from_format('Y-m-d\TH:i:s.u', $timestamp) ?: date_create_from_format('Y-m-d\TH:i:s', $timestamp))->getTimestamp();
+        $date = date_create_from_format('Y-m-d\TH:i:s.u', $timestamp)
+            ?: date_create_from_format('Y-m-d\TH:i:s', $timestamp);
+
+        return $date ? $date->getTimestamp() : 0;
     }
 
     private function exists(string $type, string $path): bool

--- a/src/BunnyCDNClient.php
+++ b/src/BunnyCDNClient.php
@@ -20,7 +20,7 @@ class BunnyCDNClient
         private string $api_key,
         private string $region = BunnyCDNRegion::FALKENSTEIN
     ) {
-        $handler = HandlerStack::create(new CurlHandler());
+        $handler = HandlerStack::create(new CurlHandler);
 
         $this->guzzleClient = new Guzzle([
             'handler' => $handler,
@@ -56,19 +56,21 @@ class BunnyCDNClient
     }
 
     /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>|string
+     *
      * @throws ClientExceptionInterface
      */
     private function request(Request $request, array $options = []): mixed
     {
         $contents = $this->guzzleClient->send($request, $options)->getBody()->getContents();
 
-        return json_decode($contents, true) ?? $contents;
+        $decoded = json_decode($contents, true);
+
+        return \is_array($decoded) ? $decoded : $contents;
     }
 
     /**
-     * @param  string  $path
-     * @return array
-     *
      * @throws NotFoundException|BunnyCDNException
      */
     public function list(string $path): array
@@ -95,9 +97,6 @@ class BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @return mixed
-     *
      * @throws BunnyCDNException
      * @throws NotFoundException
      */
@@ -122,7 +121,6 @@ class BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
      * @return resource|null
      *
      * @throws BunnyCDNException
@@ -159,10 +157,6 @@ class BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @param $contents
-     * @return mixed
-     *
      * @throws BunnyCDNException
      */
     public function upload(string $path, $contents): mixed
@@ -181,9 +175,6 @@ class BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @return mixed
-     *
      * @throws BunnyCDNException
      */
     public function make_directory(string $path): mixed
@@ -203,9 +194,6 @@ class BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @return mixed
-     *
      * @throws NotFoundException
      * @throws BunnyCDNException
      */

--- a/src/Exceptions/BunnyCDNException.php
+++ b/src/Exceptions/BunnyCDNException.php
@@ -4,6 +4,4 @@ namespace PlatformCommunity\Flysystem\BunnyCDN\Exceptions;
 
 use Exception;
 
-class BunnyCDNException extends Exception
-{
-}
+class BunnyCDNException extends Exception {}

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -2,6 +2,4 @@
 
 namespace PlatformCommunity\Flysystem\BunnyCDN\Exceptions;
 
-class NotFoundException extends BunnyCDNException
-{
-}
+class NotFoundException extends BunnyCDNException {}

--- a/src/Util.php
+++ b/src/Util.php
@@ -9,9 +9,6 @@ class Util
 {
     /**
      * Splits a path into a file and a directory
-     *
-     * @param $path
-     * @return array
      */
     public static function splitPathIntoDirectoryAndFile($path): array
     {
@@ -27,7 +24,6 @@ class Util
     }
 
     /**
-     * @param $path
      * @param  bool  $isDirectory
      * @return false|string|string[]
      */
@@ -54,21 +50,12 @@ class Util
 
     /**
      * @codeCoverageIgnore
-     *
-     * @param $haystack
-     * @param $needle
-     * @return bool
      */
     public static function startsWith($haystack, $needle): bool
     {
         return strpos($haystack, $needle) === 0;
     }
 
-    /**
-     * @param $haystack
-     * @param $needle
-     * @return bool
-     */
     public static function endsWith($haystack, $needle): bool
     {
         $length = strlen($needle);

--- a/src/WriteBatchFile.php
+++ b/src/WriteBatchFile.php
@@ -7,6 +7,5 @@ class WriteBatchFile
     public function __construct(
         public string $localPath,
         public string $targetPath,
-    ) {
-    }
+    ) {}
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,6 +2,8 @@
 
 namespace PlatformCommunity\Flysystem\BunnyCDN\Tests;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion;
@@ -215,5 +217,45 @@ class ClientTest extends TestCase
         if (is_resource($stream)) {
             fclose($stream);
         }
+    }
+
+    private function clientWithResponseBody(string $body): BunnyCDNClient
+    {
+        $client = new BunnyCDNClient('test_storage_zone', 'api-key');
+        $client->guzzleClient = new Client([
+            'handler' => function () use ($body) {
+                return new Response(200, [], $body);
+            },
+        ]);
+
+        return $client;
+    }
+
+    public function test_download_returns_raw_content_for_numeric_body(): void
+    {
+        $client = $this->clientWithResponseBody('123');
+
+        $this->assertSame('123', $client->download('/file.txt'));
+    }
+
+    public function test_download_returns_raw_content_for_boolean_body(): void
+    {
+        $client = $this->clientWithResponseBody('true');
+
+        $this->assertSame('true', $client->download('/file.txt'));
+    }
+
+    public function test_download_returns_raw_content_for_json_object_body(): void
+    {
+        $client = $this->clientWithResponseBody('{"key":"value"}');
+
+        $this->assertSame('{"key":"value"}', $client->download('/file.txt'));
+    }
+
+    public function test_list_returns_array_for_json_array_body(): void
+    {
+        $client = $this->clientWithResponseBody('[{"ObjectName":"file.txt"}]');
+
+        $this->assertSame([['ObjectName' => 'file.txt']], $client->list('/'));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,12 +2,13 @@
 
 namespace PlatformCommunity\Flysystem\BunnyCDN\Tests;
 
-use function PHPUnit\Framework\assertEmpty;
 use PHPUnit\Framework\TestCase;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\BunnyCDNException;
 use PlatformCommunity\Flysystem\BunnyCDN\Exceptions\NotFoundException;
+
+use function PHPUnit\Framework\assertEmpty;
 
 if (\is_file(__DIR__.'/ClientDI.php')) {
     require_once __DIR__.'/ClientDI.php';

--- a/tests/FlysystemAdapterTest.php
+++ b/tests/FlysystemAdapterTest.php
@@ -18,6 +18,7 @@ use League\Flysystem\UnableToProvideChecksum;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
+use PHPUnit\Framework\Attributes\Test;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNAdapter;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNRegion;
@@ -105,39 +106,33 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         $this->markTestSkipped('No visibility support is provided for BunnyCDN');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function file_exists_on_directory_is_false(): void
     {
         $this->runScenario(function () {
             $adapter = $this->adapter();
 
             $this->assertFalse($adapter->directoryExists('test'));
-            $adapter->createDirectory('test', new Config());
+            $adapter->createDirectory('test', new Config);
             $this->assertTrue($adapter->directoryExists('test'));
             $this->assertFalse($adapter->fileExists('test'));
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function directory_exists_on_file_is_false(): void
     {
         $this->runScenario(function () {
             $adapter = $this->adapter();
 
             $this->assertFalse($adapter->fileExists('test.txt'));
-            $adapter->write('test.txt', 'aaa', new Config());
+            $adapter->write('test.txt', 'aaa', new Config);
             $this->assertTrue($adapter->fileExists('test.txt'));
             $this->assertFalse($adapter->directoryExists('test.txt'));
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delete_on_directory_throws_exception(): void
     {
         $this->runScenario(function () {
@@ -154,9 +149,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delete_with_empty_path_throws_exception(): void
     {
         $this->runScenario(function () {
@@ -173,9 +166,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moving_a_folder(): void
     {
         $this->runScenario(function () {
@@ -190,7 +181,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
                 'contents to be copied',
                 new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
             );
-            $adapter->move('test', 'destination', new Config());
+            $adapter->move('test', 'destination', new Config);
             $this->assertFalse(
                 $adapter->fileExists('test/text.txt'),
                 'After moving a file should no longer exist in the original location.'
@@ -212,22 +203,18 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moving_a_not_existing_folder(): void
     {
         $this->runScenario(function () {
             $adapter = $this->adapter();
 
             $this->expectException(UnableToMoveFile::class);
-            $adapter->move('not_existing_file', 'destination', new Config());
+            $adapter->move('not_existing_file', 'destination', new Config);
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function copying_a_folder(): void
     {
         $this->runScenario(function () {
@@ -242,7 +229,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
                 'contents to be copied',
                 new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
             );
-            $adapter->copy('test', 'destination', new Config());
+            $adapter->copy('test', 'destination', new Config);
             $this->assertTrue(
                 $adapter->fileExists('test/text.txt'),
                 'After copying a file should exist in the original location.'
@@ -264,24 +251,21 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function copying_a_not_existing_folder(): void
     {
         $this->runScenario(function () {
             $adapter = $this->adapter();
 
             $this->expectException(UnableToCopyFile::class);
-            $adapter->copy('not_existing_file', 'destination', new Config());
+            $adapter->copy('not_existing_file', 'destination', new Config);
         });
     }
 
     /**
      * We overwrite the test, because the original tries accessing the url
-     *
-     * @test
      */
+    #[Test]
     public function generating_a_public_url(): void
     {
         if (self::$isLive && ! \str_starts_with(static::$publicUrl, self::DEMOURL)) {
@@ -290,7 +274,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
             return;
         }
 
-        $url = $this->adapter()->publicUrl('/path.txt', new Config());
+        $url = $this->adapter()->publicUrl('/path.txt', new Config);
 
         self::assertEquals(static::$publicUrl.'/path.txt', $url);
     }
@@ -300,27 +284,23 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('In order to get a visible URL for a BunnyCDN object, you must pass the "pullzone_url" parameter to the BunnyCDNAdapter.');
         $myAdapter = new BunnyCDNAdapter(static::bunnyCDNClient());
-        $myAdapter->publicUrl('/path.txt', new Config());
+        $myAdapter->publicUrl('/path.txt', new Config);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function generating_a_temporary_url(): void
     {
         $adapter = new BunnyCDNAdapter(self::bunnyCDNClient(), '');
         $adapter->setTokenAuthKey('test-key');
 
         $expiresAt = new \DateTimeImmutable('+1 hour');
-        $url = $adapter->temporaryUrl('path.txt', $expiresAt, new Config());
+        $url = $adapter->temporaryUrl('path.txt', $expiresAt, new Config);
 
         $this->assertStringContainsString('path.txt?token=', $url);
         $this->assertStringContainsString('&expires=', $url);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overwriting_a_file(): void
     {
         $this->runScenario(function () {
@@ -336,9 +316,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function writing_a_file_using_a_stream(): void
     {
         $this->runScenario(function () {
@@ -348,7 +326,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
             fwrite($stream, 'contents');
             rewind($stream);
 
-            $adapter->writeStream('path.txt', $stream, new Config());
+            $adapter->writeStream('path.txt', $stream, new Config);
 
             $this->assertTrue($adapter->fileExists('path.txt'));
             $this->assertEquals('contents', $adapter->read('path.txt'));
@@ -358,9 +336,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moving_a_file_to_same_destination(): void
     {
         $this->runScenario(function () {
@@ -370,7 +346,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
                 'contents to be copied',
                 new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
             );
-            $adapter->move('source.txt', 'source.txt', new Config());
+            $adapter->move('source.txt', 'source.txt', new Config);
             $this->assertTrue(
                 $adapter->fileExists('source.txt'),
                 'After moving a file to the same location the file should exist.'
@@ -378,18 +354,16 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function get_checksum(): void
     {
         $adapter = $this->adapter();
 
-        $adapter->write('path.txt', 'foobar', new Config());
+        $adapter->write('path.txt', 'foobar', new Config);
 
         $this->assertSame(
             '3858f62230ac3c915f300c664312c63f',
-            $adapter->checksum('path.txt', new Config())
+            $adapter->checksum('path.txt', new Config)
         );
 
         $this->assertSame(
@@ -406,7 +380,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         $adapter->checksum('path.txt', new Config(['checksum_algo' => 'sha256']));
     }
 
-    //test_checksum_throws_error_with_empty_checksum_from_client
+    // test_checksum_throws_error_with_empty_checksum_from_client
     public function test_checksum_throws_error_with_empty_checksum_from_client(): void
     {
         $client = $this->createMock(BunnyCDNClient::class);
@@ -444,9 +418,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
         $adapter->checksum('file.txt', new Config(['checksum_algo' => 'sha256']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fetching_the_mime_type_of_an_svg_file_by_file_name(): void
     {
         $this->runScenario(function () {
@@ -454,7 +426,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
             $adapter->write(
                 'source.svg',
                 '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>',
-                new Config()
+                new Config
             );
 
             $this->assertSame(
@@ -568,7 +540,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
                     new WriteBatchFile($firstTmpPath, 'destination.txt'),
                     new WriteBatchFile($secondTmpPath, 'destination2.txt'),
                 ],
-                new Config()
+                new Config
             );
 
             \fclose($firstTmpFile);
@@ -602,7 +574,7 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
                     new WriteBatchFile($firstTmpPath, 'failing.txt'),
                     new WriteBatchFile($secondTmpPath, 'failing2.txt'),
                 ],
-                new Config()
+                new Config
             );
 
             \fclose($firstTmpFile);

--- a/tests/FlysystemAdapterTest.php
+++ b/tests/FlysystemAdapterTest.php
@@ -12,6 +12,7 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\UnableToCopyFile;
+use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToProvideChecksum;
@@ -580,5 +581,48 @@ class FlysystemAdapterTest extends FilesystemAdapterTestCase
             \fclose($firstTmpFile);
             \fclose($secondTmpFile);
         });
+    }
+
+    public function test_delete_directory_on_root_throws_exception(): void
+    {
+        $this->expectException(UnableToDeleteDirectory::class);
+        $adapter = $this->adapter();
+        $adapter->deleteDirectory('');
+    }
+
+    public function test_delete_directory_on_slashed_root_throws_exception(): void
+    {
+        $this->expectException(UnableToDeleteDirectory::class);
+        $adapter = $this->adapter();
+        $adapter->deleteDirectory('/');
+    }
+
+    public function test_last_modified_with_malformed_timestamp_does_not_crash(): void
+    {
+        $client = $this->createMock(BunnyCDNClient::class);
+
+        $client->expects(self::exactly(1))->method('list')->willReturn([
+            [
+                'Guid' => 'guid',
+                'StorageZoneName' => 'test_storage_zone',
+                'Path' => '/test_storage_zone/',
+                'ObjectName' => 'file.txt',
+                'Length' => 10,
+                'LastChanged' => 'not-a-valid-timestamp',
+                'ServerId' => 1,
+                'ArrayNumber' => 0,
+                'IsDirectory' => false,
+                'UserId' => 'user',
+                'ContentType' => '',
+                'DateCreated' => 'not-a-valid-timestamp',
+                'StorageZoneId' => 1,
+                'Checksum' => null,
+                'ReplicatedZones' => '',
+            ],
+        ]);
+
+        $adapter = new BunnyCDNAdapter($client);
+
+        $this->assertSame(0, $adapter->lastModified('file.txt')->lastModified());
     }
 }

--- a/tests/MockClient.php
+++ b/tests/MockClient.php
@@ -17,9 +17,6 @@ use PlatformCommunity\Flysystem\BunnyCDN\Util;
 
 class MockClient extends BunnyCDNClient
 {
-    /**
-     * @var Filesystem
-     */
     public Filesystem $filesystem;
 
     public Guzzle $guzzleClient;
@@ -27,13 +24,9 @@ class MockClient extends BunnyCDNClient
     public function __construct(string $storage_zone_name, string $api_key, string $region = '')
     {
         parent::__construct($storage_zone_name, $api_key, $region);
-        $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter);
     }
 
-    /**
-     * @param  string  $path
-     * @return array
-     */
     public function list(string $path): array
     {
         try {
@@ -52,9 +45,6 @@ class MockClient extends BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @return string
-     *
      * @throws FilesystemException
      */
     public function download(string $path): string
@@ -63,7 +53,6 @@ class MockClient extends BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
      * @return resource
      *
      * @throws FilesystemException
@@ -73,11 +62,6 @@ class MockClient extends BunnyCDNClient
         return $this->filesystem->readStream($path);
     }
 
-    /**
-     * @param  string  $path
-     * @param $contents
-     * @return array
-     */
     public function upload(string $path, $contents): array
     {
         try {
@@ -97,10 +81,6 @@ class MockClient extends BunnyCDNClient
         return [];
     }
 
-    /**
-     * @param  string  $path
-     * @return array
-     */
     public function make_directory(string $path): array
     {
         try {
@@ -117,9 +97,6 @@ class MockClient extends BunnyCDNClient
     }
 
     /**
-     * @param  string  $path
-     * @return array
-     *
      * @throws FilesystemException
      * @throws BunnyCDNException
      * @throws NotFoundException
@@ -129,7 +106,7 @@ class MockClient extends BunnyCDNClient
         try {
             $this->filesystem->has($path) ?
                 $this->filesystem->deleteDirectory($path) || $this->filesystem->delete($path) :
-                throw new NotFoundException();
+                throw new NotFoundException;
 
             return [
                 'HttpCode' => 200,

--- a/tests/PrefixTest.php
+++ b/tests/PrefixTest.php
@@ -10,6 +10,7 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\Visibility;
+use PHPUnit\Framework\Attributes\Test;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNAdapter;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
 
@@ -52,7 +53,7 @@ class PrefixTest extends FilesystemAdapterTestCase
         );
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         try {
             (new Filesystem(self::bunnyCDNAdapter()))->deleteDirectory('/'.self::PREFIX_PATH);
@@ -74,12 +75,11 @@ class PrefixTest extends FilesystemAdapterTestCase
 
     /**
      * We overwrite the test, because the original tries accessing the url
-     *
-     * @test
      */
+    #[Test]
     public function generating_a_public_url(): void
     {
-        $url = $this->adapter()->publicUrl('path.txt', new Config());
+        $url = $this->adapter()->publicUrl('path.txt', new Config);
 
         self::assertEquals('https://example.org.local/assets/path_prefix_12345/path.txt', $url);
     }
@@ -99,9 +99,7 @@ class PrefixTest extends FilesystemAdapterTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function generating_a_temporary_url(): void
     {
         $adapter = new BunnyCDNAdapter(self::bunnyCDNClient(), 'https://example.org.local/assets/');
@@ -110,15 +108,13 @@ class PrefixTest extends FilesystemAdapterTestCase
         $prefixAdapter = new PathPrefixedAdapter($adapter, self::PREFIX_PATH);
 
         $expiresAt = new \DateTimeImmutable('+1 hour');
-        $url = $prefixAdapter->temporaryUrl('path.txt', $expiresAt, new Config());
+        $url = $prefixAdapter->temporaryUrl('path.txt', $expiresAt, new Config);
 
         $this->assertStringContainsString(self::PREFIX_PATH.'/path.txt?token=', $url);
         $this->assertStringContainsString('&expires=', $url);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function get_checksum(): void
     {
         $adapter = $this->adapter();
@@ -127,11 +123,11 @@ class PrefixTest extends FilesystemAdapterTestCase
             $this->markTestSkipped('Adapter does not supply providing checksums');
         }
 
-        $adapter->write('path.txt', 'foobar', new Config());
+        $adapter->write('path.txt', 'foobar', new Config);
 
         $this->assertSame(
             '3858f62230ac3c915f300c664312c63f',
-            $adapter->checksum('path.txt', new Config())
+            $adapter->checksum('path.txt', new Config)
         );
 
         $this->assertSame(
@@ -140,16 +136,27 @@ class PrefixTest extends FilesystemAdapterTestCase
         );
     }
 
-    public function test_construct_throws_error(): void
+    public function test_construct_with_root_argument_scopes_operations(): void
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('PrefixPath is no longer supported directly. Use PathPrefixedAdapter instead: https://flysystem.thephpleague.com/docs/adapter/path-prefixing/');
-        new BunnyCDNAdapter(self::bunnyCDNClient(), 'https://example.org.local/assets/', 'thisisauselessarg');
+        $client = self::bunnyCDNClient();
+        $adapter = new BunnyCDNAdapter($client, 'https://example.org.local/assets/', self::PREFIX_PATH);
+        $adapter->setTokenAuthKey('test-token-auth-key');
+
+        $unscopedAdapter = new BunnyCDNAdapter($client, 'https://example.org.local/assets/');
+
+        $adapter->write('source.file.svg', 'root-scoped contents', new Config);
+        $this->assertTrue($adapter->fileExists('source.file.svg'));
+        $this->assertFalse($unscopedAdapter->fileExists('source.file.svg'));
+
+        $this->assertTrue($unscopedAdapter->fileExists(self::PREFIX_PATH.'/source.file.svg'));
+        $this->assertSame('root-scoped contents', $unscopedAdapter->read(self::PREFIX_PATH.'/source.file.svg'));
+
+        $adapter->delete('source.file.svg');
+        $this->assertFalse($adapter->fileExists('source.file.svg'));
+        $this->assertFalse($unscopedAdapter->fileExists(self::PREFIX_PATH.'/source.file.svg'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prefix_path(): void
     {
         $this->runScenario(function () {
@@ -280,11 +287,10 @@ class PrefixTest extends FilesystemAdapterTestCase
     }
 
     /**
-     * @test
-     *
      * @throws FilesystemException
      * @throws \Throwable
      */
+    #[Test]
     public function prefix_path_not_in_meta_pr_36(): void
     {
         $this->dontRetryOnException();

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace PlatformCommunity\Flysystem\BunnyCDN\Tests;
+
+use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
+use League\Flysystem\Config;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
+use League\Flysystem\Visibility;
+use PHPUnit\Framework\Attributes\Test;
+use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNAdapter;
+use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
+
+if (\is_file(__DIR__.'/ClientDI.php')) {
+    require_once __DIR__.'/ClientDI.php';
+}
+
+class RootTest extends FilesystemAdapterTestCase
+{
+    /**
+     * Root path the adapter is scoped to.
+     */
+    public const ROOT_PATH = 'root_prefix_12345';
+
+    private static function bunnyCDNClient(): BunnyCDNClient
+    {
+        global $storage_zone;
+        global $api_key;
+
+        if ($storage_zone !== null && $api_key !== null) {
+            return new BunnyCDNClient($storage_zone, $api_key);
+        }
+
+        return new MockClient('test_storage_zone', '123');
+    }
+
+    private static function bunnyCDNAdapter(): BunnyCDNAdapter
+    {
+        $adapter = new BunnyCDNAdapter(self::bunnyCDNClient(), 'https://example.org.local/assets/', self::ROOT_PATH);
+        $adapter->setTokenAuthKey('test-token-auth-key');
+
+        return $adapter;
+    }
+
+    public static function createFilesystemAdapter(): FilesystemAdapter
+    {
+        return self::bunnyCDNAdapter();
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            (new Filesystem(self::bunnyCDNAdapter()))->deleteDirectory('');
+        } catch (FilesystemException $e) {
+        }
+    }
+
+    /**
+     * Skipped
+     */
+    public function setting_visibility(): void
+    {
+        $this->markTestSkipped('No visibility support is provided for BunnyCDN');
+    }
+
+    /**
+     * We overwrite the test, because the original tries accessing the url
+     */
+    #[Test]
+    public function generating_a_public_url(): void
+    {
+        $url = $this->adapter()->publicUrl('path.txt', new Config);
+
+        self::assertEquals('https://example.org.local/assets/'.self::ROOT_PATH.'/path.txt', $url);
+    }
+
+    public function overwriting_a_file(): void
+    {
+        $this->runScenario(function () {
+            $this->givenWeHaveAnExistingFile('path.txt', 'contents', ['visibility' => Visibility::PUBLIC]);
+            $adapter = $this->adapter();
+
+            $adapter->write('path.txt', 'new contents', new Config(['visibility' => Visibility::PRIVATE]));
+
+            $contents = $adapter->read('path.txt');
+            $this->assertEquals('new contents', $contents);
+        });
+    }
+
+    /**
+     * Files written through a root-scoped adapter must not leak outside of the root.
+     */
+    #[Test]
+    public function files_are_scoped_to_the_root(): void
+    {
+        $this->runScenario(function () {
+            $client = self::bunnyCDNClient();
+            $adapter = new BunnyCDNAdapter($client, 'https://example.org.local/assets/', self::ROOT_PATH);
+            $unscopedAdapter = new BunnyCDNAdapter($client, 'https://example.org.local/assets/');
+
+            $adapter->write('path.txt', 'root-scoped contents', new Config);
+
+            $this->assertTrue($adapter->fileExists('path.txt'));
+            $this->assertFalse($unscopedAdapter->fileExists('path.txt'));
+            $this->assertTrue($unscopedAdapter->fileExists(self::ROOT_PATH.'/path.txt'));
+            $this->assertSame('root-scoped contents', $unscopedAdapter->read(self::ROOT_PATH.'/path.txt'));
+
+            $adapter->delete('path.txt');
+            $this->assertFalse($unscopedAdapter->fileExists(self::ROOT_PATH.'/path.txt'));
+        });
+    }
+
+    /**
+     * Temporary URLs must be signed against the root-scoped path.
+     */
+    #[Test]
+    public function generating_a_temporary_url(): void
+    {
+        $adapter = self::bunnyCDNAdapter();
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->temporaryUrl('path.txt', $expiresAt, new Config);
+
+        $this->assertStringContainsString(self::ROOT_PATH.'/path.txt?token=', $url);
+        $this->assertStringContainsString('&expires=', $url);
+    }
+
+    /**
+     * The root path must not appear in listed paths (logical paths are root-relative).
+     */
+    #[Test]
+    public function listed_paths_do_not_contain_the_root(): void
+    {
+        $this->runScenario(function () {
+            $adapter = self::bunnyCDNAdapter();
+            $adapter->write('folder/file.txt', 'contents', new Config);
+
+            $rootListing = \iterator_to_array($adapter->listContents('', false));
+            $this->assertCount(1, $rootListing);
+            $this->assertSame('folder', $rootListing[0]['path']);
+
+            $folderListing = \iterator_to_array($adapter->listContents('folder', false));
+            $this->assertCount(1, $folderListing);
+            $this->assertSame('folder/file.txt', $folderListing[0]['path']);
+        });
+    }
+
+    /**
+     * PathPrefixedAdapter on top of a root-scoped adapter keeps working.
+     */
+    #[Test]
+    public function root_can_be_combined_with_path_prefixing(): void
+    {
+        $adapter = self::bunnyCDNAdapter();
+        $prefixed = new PathPrefixedAdapter($adapter, 'additional_prefix');
+
+        $prefixed->write('path.txt', 'contents', new Config);
+
+        $this->assertTrue($adapter->fileExists('additional_prefix/path.txt'));
+        $this->assertFalse($adapter->fileExists('path.txt'));
+
+        $this->assertSame('contents', $prefixed->read('path.txt'));
+    }
+}

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -2,6 +2,9 @@
 
 namespace PlatformCommunity\Flysystem\BunnyCDN\Tests;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
 use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
@@ -12,6 +15,7 @@ use League\Flysystem\Visibility;
 use PHPUnit\Framework\Attributes\Test;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNAdapter;
 use PlatformCommunity\Flysystem\BunnyCDN\BunnyCDNClient;
+use PlatformCommunity\Flysystem\BunnyCDN\WriteBatchFile;
 
 if (\is_file(__DIR__.'/ClientDI.php')) {
     require_once __DIR__.'/ClientDI.php';
@@ -173,6 +177,49 @@ class RootTest extends FilesystemAdapterTestCase
             $url = $adapter->temporaryUrl('folder/path.txt', new \DateTimeImmutable('+1 hour'), new Config);
             $this->assertStringContainsString(self::ROOT_PATH.'/folder/path.txt?token=', $url);
         });
+    }
+
+    /**
+     * writeBatch must upload to root-scoped paths.
+     */
+    #[Test]
+    public function write_batch_uses_root_scoped_paths(): void
+    {
+        $mockedClient = new MockClient('test_storage_zone', '123');
+        $mockedClient->guzzleClient = new Client([
+            'handler' => function (Request $request) use ($mockedClient) {
+                if ($request->getMethod() !== 'PUT') {
+                    throw new \RuntimeException('Unexpected request: '.$request->getMethod().' '.$request->getUri());
+                }
+
+                $path = \ltrim(\str_replace('/test_storage_zone', '', $request->getUri()->getPath()), '/');
+                $mockedClient->filesystem->write($path, (string) $request->getBody());
+
+                return new Response(200);
+            },
+        ]);
+
+        $adapter = new BunnyCDNAdapter($mockedClient, 'https://example.org.local/assets/', self::ROOT_PATH);
+
+        $firstTmpFile = \tmpfile();
+        fwrite($firstTmpFile, 'text');
+        $secondTmpFile = \tmpfile();
+        fwrite($secondTmpFile, 'text2');
+
+        $adapter->writeBatch(
+            [
+                new WriteBatchFile(stream_get_meta_data($firstTmpFile)['uri'], 'destination.txt'),
+                new WriteBatchFile(stream_get_meta_data($secondTmpFile)['uri'], 'destination2.txt'),
+            ],
+            new Config
+        );
+
+        \fclose($firstTmpFile);
+        \fclose($secondTmpFile);
+
+        $this->assertTrue($adapter->fileExists('destination.txt'));
+        $this->assertSame('text', $adapter->read('destination.txt'));
+        $this->assertSame('text2', $adapter->read('destination2.txt'));
     }
 
     /**

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -148,6 +148,34 @@ class RootTest extends FilesystemAdapterTestCase
     }
 
     /**
+     * The root path is normalized: trailing slashes must not break scoping or URL generation.
+     */
+    #[Test]
+    public function root_with_trailing_slash_is_normalized(): void
+    {
+        $this->runScenario(function () {
+            $client = self::bunnyCDNClient();
+            $adapter = new BunnyCDNAdapter($client, 'https://example.org.local/assets/', self::ROOT_PATH.'/');
+
+            $adapter->write('folder/path.txt', 'contents', new Config);
+            $this->assertTrue($adapter->fileExists('folder/path.txt'));
+
+            $listing = \iterator_to_array($adapter->listContents('folder', false));
+            $this->assertCount(1, $listing);
+            $this->assertSame('folder/path.txt', $listing[0]['path']);
+
+            $this->assertSame(
+                'https://example.org.local/assets/'.self::ROOT_PATH.'/folder/path.txt',
+                $adapter->publicUrl('folder/path.txt', new Config)
+            );
+
+            $adapter->setTokenAuthKey('test-token-auth-key');
+            $url = $adapter->temporaryUrl('folder/path.txt', new \DateTimeImmutable('+1 hour'), new Config);
+            $this->assertStringContainsString(self::ROOT_PATH.'/folder/path.txt?token=', $url);
+        });
+    }
+
+    /**
      * PathPrefixedAdapter on top of a root-scoped adapter keeps working.
      */
     #[Test]

--- a/tests/TemporaryUrlTest.php
+++ b/tests/TemporaryUrlTest.php
@@ -19,7 +19,7 @@ class TemporaryUrlTest extends TestCase
         $adapter = new BunnyCDNAdapter($client, 'pz-key');
 
         $expiresAt = new \DateTimeImmutable('+1 hour');
-        $adapter->temporaryUrl('testing.text', $expiresAt, new Config());
+        $adapter->temporaryUrl('testing.text', $expiresAt, new Config);
     }
 
     public function test_it_can_generate_signing_key()
@@ -29,7 +29,7 @@ class TemporaryUrlTest extends TestCase
         $adapter->setTokenAuthKey('test-auth-key');
 
         $expiresAt = new \DateTimeImmutable('+1 hour');
-        $url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config());
+        $url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config);
 
         $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
         $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
@@ -51,5 +51,62 @@ class TemporaryUrlTest extends TestCase
         $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
         $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
         $this->assertStringContainsString('testParam=testValue', $url);
+    }
+
+    public function test_it_can_generate_temporary_url_via_laravel_compatible_method(): void
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->getTemporaryUrl('testing.txt', $expiresAt, []);
+
+        $this->assertSame(
+            $adapter->temporaryUrl('testing.txt', $expiresAt, new Config),
+            $url
+        );
+    }
+
+    public function test_it_can_generate_temporary_url_with_minutes_as_expiration(): void
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresIn = 60;
+        $url = $adapter->getTemporaryUrl('testing.txt', $expiresIn, []);
+
+        $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
+        $this->assertStringContainsString('expires='.(time() + ($expiresIn * 60)), $url);
+    }
+
+    public function test_it_can_generate_temporary_url_with_options_as_query_params(): void
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->getTemporaryUrl('testing.txt', $expiresAt, [
+            'testParam' => 'testValue',
+        ]);
+
+        $this->assertStringContainsString('https://pz-url.co.uk/testing.txt?token=', $url);
+        $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
+        $this->assertStringContainsString('testParam=testValue', $url);
+    }
+
+    public function test_temporary_url_with_root_scopes_the_signed_path(): void
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk', 'assets');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->temporaryUrl('testing.txt', $expiresAt, new Config);
+
+        $this->assertStringContainsString('https://pz-url.co.uk/assets/testing.txt?token=', $url);
+        $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
     }
 }

--- a/tests/TemporaryUrlTest.php
+++ b/tests/TemporaryUrlTest.php
@@ -109,4 +109,19 @@ class TemporaryUrlTest extends TestCase
         $this->assertStringContainsString('https://pz-url.co.uk/assets/testing.txt?token=', $url);
         $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
     }
+
+    public function test_temporary_url_with_full_url_path_does_not_apply_root(): void
+    {
+        $client = new BunnyCDNClient('test', 'test');
+        $adapter = new BunnyCDNAdapter($client, 'https://pz-url.co.uk', 'assets');
+        $adapter->setTokenAuthKey('test-auth-key');
+
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $url = $adapter->temporaryUrl('https://cdn.example.org/path/file.txt?download=file.txt', $expiresAt, new Config);
+
+        $this->assertStringContainsString('https://cdn.example.org/path/file.txt', $url);
+        $this->assertStringContainsString('token=', $url);
+        $this->assertStringNotContainsString('/assets', $url);
+        $this->assertStringContainsString('expires='.$expiresAt->getTimestamp(), $url);
+    }
 }

--- a/tests/UtilityClassTest.php
+++ b/tests/UtilityClassTest.php
@@ -3,16 +3,16 @@
 namespace PlatformCommunity\Flysystem\BunnyCDN\Tests;
 
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PlatformCommunity\Flysystem\BunnyCDN\Util;
 
 class UtilityClassTest extends TestCase
 {
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function it_starts_with()
     {
         $this->assertTrue(
@@ -25,10 +25,9 @@ class UtilityClassTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function it_ends_with()
     {
         $this->assertTrue(
@@ -45,10 +44,9 @@ class UtilityClassTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function it_tests_normalize_path()
     {
         $this->assertEquals(
@@ -68,10 +66,9 @@ class UtilityClassTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @throws Exception
      */
+    #[Test]
     public function it_path_split()
     {
         $this->assertEquals(


### PR DESCRIPTION
## Summary

Maintenance pass over the v3 line: dependency updates, two open-issue fixes, several latent bugs, and modernized CI/static analysis.

## Dependency updates (composer.json)

- **PHP floor `^8.3`** — PHP 8.2 reaches EOL on 31 Dec 2026. (Pint 1.x also requires ^8.3.)
- **`fzaninotto/faker` → `fakerphp/faker`** — abandoned package; drop-in replacement, same `Faker\` namespace.
- **`laravel/pint` `^0.2.3` → `^1.30`** — fixes PHP 8.5 deprecation warnings from the old Pint build.
- **`phpunit/phpunit` `^10.0` → `^11.5`** — 10.x is EOL. PHPUnit 12+ is *not* viable: it removed doc-comment metadata support, which `league/flysystem-adapter-test-utilities` still relies on (test discovery drops from 158 → 22).

## Issue fixes

- **#97 — Laravel `Storage::temporaryUrl()` throws "This driver does not support creating temporary URLs"**: Laravel's `FilesystemAdapter` only calls `getTemporaryUrl()` on the adapter; it was never implemented. Added `BunnyCDNAdapter::getTemporaryUrl()` (accepts `DateTimeInterface` or minutes, plus signed query-param options) — `Storage::disk('bunnycdn')->temporaryUrl()` now works out of the box.
- **#96 / discussion #30 — `root` setting does not work**: the third constructor argument (which previously threw "PrefixPath is no longer supported") is now a real **root path prefix** — v1 semantics restored. All operations (write/read/list/delete/move/copy/URLs) are scoped to the root; listed paths are root-relative; public and temporary URLs include the root and temporary-URL signatures are built from the root-scoped path. Documented in the README incl. the Laravel `root` config.

## Bugs found during review

- **`deleteDirectory('')` could DELETE the storage zone root** — now guarded with `UnableToDeleteDirectory`.
- **`request()` json_decode edge case** — a file whose content is numeric (`123`) or `true` decoded to `int`/`bool` and `download()` threw a `TypeError` against its `string` return type. Non-array JSON payloads now return the raw body.
- **`parse_bunny_timestamp()`** — fatal error on malformed timestamps; now falls back to `0`.
- **`writeBatch` failure reporting** — `UnableToWriteFile::atLocation()` received a numeric pool index instead of the target path.
- **`lastModified()`/`fileSize()`** relied on a return-type `TypeError` for directory paths; now an explicit `UnableToRetrieveMetadata` (same external behavior, flagged by PHPStan).

## Tooling / CI

- **PHPStan** level 0 → **5** via new `phpstan.neon.dist`; all reported issues fixed.
- Tests converted from `@test` doc-comments to `#[Test]` attributes (deprecated in PHPUnit 11); import added.
- **New `tests/RootTest.php`** — full flysystem conformance suite against a root-scoped adapter (63 tests) plus targeted root tests.
- **CI** (`php.yml`): `checkout@v4`, `setup-php@v4`, PHP matrix `8.3/8.4/8.5`, local `vendor/bin/phpstan` run (guarded so legacy `v1`/`v2` branches — which don't ship pint/phpstan — keep working), `codecov-action@v5` replacing the deprecated bash uploader.

## Verification

- 225 tests, 440 assertions — all green (was 158; +63 RootTest conformance, +4 temp-URL tests)
- `composer validate --strict`, Pint, PHPStan level 5 — all clean
- No composer security advisories

## Notes

- `composer.lock` stays gitignored (library convention).
- Local stray `.git.broken/` directory found in the repo root — untracked, not included in this PR.